### PR TITLE
Added pagination to merchants and items.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,10 @@ gem 'sinatra', require: 'sinatra/base'
 gem 'pg'
 gem 'activerecord'
 gem 'sinatra-activerecord'
+gem 'will_paginate', '~> 3.0'
 gem 'pry'
 
 group :development, :test do
-  gem 'pry'
   gem 'shotgun'
   gem 'rspec'
   gem 'rspec-core'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
       sinatra (>= 1.2.1)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
+    will_paginate (3.1.6)
     xpath (3.0.0)
       nokogiri (~> 1.8)
 
@@ -108,6 +109,7 @@ DEPENDENCIES
   sinatra
   sinatra-activerecord
   tux
+  will_paginate (~> 3.0)
 
 BUNDLED WITH
    1.16.1

--- a/app/controllers/little_shop_app.rb
+++ b/app/controllers/little_shop_app.rb
@@ -1,11 +1,15 @@
+require 'will_paginate'
+require 'will_paginate/active_record'
+
 class LittleShopApp < Sinatra::Base
+	register WillPaginate::Sinatra
 
   get '/' do
     erb :"homepage"
   end
 
   get '/merchants' do
-    @merchants = Merchant.all
+    @merchants = Merchant.paginate(:page => params[:page])
     erb :"merchants/index"
   end
 
@@ -39,7 +43,7 @@ class LittleShopApp < Sinatra::Base
   end
 
   get '/items' do
-    @items = Item.all
+    @items = Item.paginate(:page => params[:page])
     erb :"items/index"
   end
 

--- a/app/public/stylesheets/main.css
+++ b/app/public/stylesheets/main.css
@@ -235,3 +235,10 @@ nav button {
 .show {
   padding: 30px;
 }
+
+.pagination-numbers {
+    display: flex;
+    justify-content: space-between;
+    width: 60%;
+    padding: 30px;
+}

--- a/app/views/items/index.erb
+++ b/app/views/items/index.erb
@@ -37,8 +37,11 @@
             </div>
       </div>
       </div>
-      <div class="search_bar">
-         <input type="search" name="search" placeholder="search..">
+       <div class="search_bar">
+        <form action="/search" method="GET">
+          <input type="text" placeholder="Search.." name="q">
+          <button type="submit">Submit</button>
+        </form>
       </div>
     </nav>
     <h4>Peruse All Available Wares</h4>

--- a/app/views/items/index.erb
+++ b/app/views/items/index.erb
@@ -59,5 +59,16 @@
       </div>
       <% end %>
     </section>
+
+    <div class="pagination">
+      <div class="digg-pagination">
+        <div class="page-info">
+          <%= page_entries_info @items %>
+        </div>
+        <div class="pagination-numbers">
+        <%= will_paginate @items, :container => false %>
+        </div>
+      </div>
+    </div>
   </body>
 </html>

--- a/app/views/merchants/index.erb
+++ b/app/views/merchants/index.erb
@@ -59,5 +59,16 @@
         </div>
       <% end %>
     </section>
+
+    <div class="pagination">
+      <div class="digg-pagination">
+        <div class="page-info">
+          <%= page_entries_info @merchants %>
+        </div>
+        <div class="pagination-numbers">
+        <%= will_paginate @merchants, :container => false %>
+        </div>
+      </div>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
Merchant and Item indexes now have 30 item pages. Page numbers on the bottom also show what is the active page you are on. 
<img width="1167" alt="screen shot 2018-01-30 at 12 19 44 am" src="https://user-images.githubusercontent.com/26174903/35553020-5af1144e-0553-11e8-8abf-872105850cb3.png">
